### PR TITLE
Feature/twitter consistency

### DIFF
--- a/config/site.php
+++ b/config/site.php
@@ -43,7 +43,8 @@ return [
 					'consumer_secret' => env('TWITTER_CONSUMER_SECRET'),
 					'token'           => env('TWITTER_TOKEN'),
 					'token_secret'    => env('TWITTER_TOKEN_SECRET')
-				]
+				],
+				'hashtags' => explode('|', env('TWITTER_HASHTAGS', ''))
 			],
 			'facebook' => [
 				'title' => 'Facebook',


### PR DESCRIPTION
This will require the site's `.env` file to be updated to include a `TWITTER_HASHTAGS` variable which has a string, delimited by the `|` character of hashtags to use when searching for tweets to display.